### PR TITLE
exploit recursive clone of gFTL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "git-submodules/yaFyaml"]
 	path = git-submodules/yaFyaml
 	url = git@github.com:Goddard-Fortran-Ecosystem/yaFyaml
-[submodule "git-submodules/gftl"]
-	path = git-submodules/gftl
-	url = git@github.com:Goddard-Fortran-Ecosystem/gftl
-[submodule "git-submodules/gftl-shared"]
-	path = git-submodules/gftl-shared
-	url = git@github.com:Goddard-Fortran-Ecosystem/gftl-shared
+[submodule "git-submodules/gFTL-shared"]
+	path = git-submodules/gFTL-shared
+	url = git@github.com:Goddard-Fortran-Ecosystem/gFTL-shared

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,15 +7,15 @@ project(yaFyamlSuperbuild
 include(ExternalProject)
 set(installDir ${CMAKE_CURRENT_BINARY_DIR}/install)
 
-ExternalProject_Add(gftl_shared
- SOURCE_DIR ${PROJECT_SOURCE_DIR}/git-submodules/gftl-shared
+ExternalProject_Add(gFTL_shared
+ SOURCE_DIR ${PROJECT_SOURCE_DIR}/git-submodules/gFTL-shared
  INSTALL_DIR ${installDir}
  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
             -DCMAKE_PREFIX_PATH:PATH=<INSTALL_DIR>
 )
 
-ExternalProject_Add(gftl
- SOURCE_DIR ${PROJECT_SOURCE_DIR}/git-submodules/gftl
+ExternalProject_Add(gFTL
+ SOURCE_DIR ${PROJECT_SOURCE_DIR}/git-submodules/gFTL-shared/extern/gFTL
  INSTALL_DIR ${installDir}
  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
             -DCMAKE_PREFIX_PATH:PATH=<INSTALL_DIR>
@@ -26,7 +26,7 @@ ExternalProject_Add(yaFyaml
  INSTALL_DIR ${installDir}
  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
             -DCMAKE_PREFIX_PATH:PATH=<INSTALL_DIR>
- DEPENDS gftl gftl_shared
+ DEPENDS gFTL gFTL_shared
 )
 
 # Making the tests directory an external project ensures that it is

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ This CMake project aims to build and test the following dependency tree:
 
 ```
 yaFyaml
-|__ gftl
-|__ gftl-shared
+|-- gftl-shared
+    |-- gftl
 ```
 where
 
 * [yaFyaml] is a modern Fortran YAML API,
-* [gftl] is the Goddard Fortran Template Library, and
-* [gftl-shared] contains common gFTL containers of Fortran intrinsic types.
+* [gFTL-shared] contains common gFTL containers of Fortran intrinsic types.
+* [gFTL] is the Goddard Fortran Template Library, and
 
 This is a first experiment with CMake superbuilds. The idea is
 to use the [Developer Build] pattern so that the superbuild is


### PR DESCRIPTION
This commit removes the explicit download of gFTL and instead
simply downloads it through a recursive clone of gFTL-shared.